### PR TITLE
update parse_anchors string search

### DIFF
--- a/bin/get_anchors.py
+++ b/bin/get_anchors.py
@@ -129,7 +129,6 @@ def main():
         use_std = False
     if sample_list.shape[1] == 1:
         use_std = True
-    print(use_std)
 
     # get list of samples from fastq_files
     # if fastq_file = "file1.fastq.gz", sample = "file1"

--- a/modules/local/parse_anchors.nf
+++ b/modules/local/parse_anchors.nf
@@ -23,7 +23,7 @@ process PARSE_ANCHORS {
     out_consensus_fasta_file    = "${fastq_id}_${direction}.fasta"
     out_counts_file             = "${fastq_id}_${direction}_counts.tab"
     out_fractions_file          = "${fastq_id}_${direction}_fractions.tab"
-    out_adj_kmer_file           = "${fastq_id}_target_counts.tsv"
+    out_target_file           = "${fastq_id}_target_counts.tsv"
     """
     parse_anchors.py \\
         --num_parse_anchors_reads ${num_parse_anchors_reads} \\
@@ -33,7 +33,7 @@ process PARSE_ANCHORS {
         --out_consensus_fasta_file ${out_consensus_fasta_file} \\
         --out_counts_file ${out_counts_file} \\
         --out_fractions_file ${out_fractions_file} \\
-        --out_adj_kmer_file ${out_adj_kmer_file} \\
+        --out_target_file ${out_target_file} \\
         --consensus_length ${consensus_length} \\
         --kmer_size ${kmer_size} \\
         --direction ${direction} \\


### PR DESCRIPTION
In the previous version of parse_anchors, we were searching each read for each anchor, this was quite slow. In this new version, a dictionary is intialized with anchors as keys. The read is then tiled by 1bp and each read tile is checked to see if it belongs to the anchor dict. This results in a faster run time.