### PR TITLE
add distance bounding to score computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ nextflow run kaitlinchaung/stringstats \
 | --anchor_mode | Mode of fetching candidate anchors from reads, options: `chunk`, `tile` | `tile` |
 | --window_slide | If `--anchor_mode tile`, the number of bases to slide across the read to fetch the candidate anchors. If `--window_slide 5`, candidate anchors will start at positions [0,4,9,...] | 5 |
 | --use_std | Boolean value if the anchor significance scores should be computed with standard deviation, options: `true`, `false` | `true` |
-| --compute_target_distance | Boolean value if the target distance should be computed upon the encounter of a target. If `--compute_target_distance false`, the target distance of a new target will be assigned a conservative estimate of 1, options: `true`, `false` | `false` |
+| --compute_target_distance | Boolean value if the target distance should be computed upon the encounter of a target. If `--compute_target_distance false`, the target distance of a new target will be assigned a conservative estimate of 1, options: `true`, `false` | `trie` |
+| --bound_distance | Boolean value if the target distances should be bound by `--max_distance`. If `--bound_distance true`, the maximum target distance will be `--max_distance`, options: `true`, `false` | `true` |
+| --max_distance | Integer value of the maximum target distance allowed | 10 |
+
 
 `parse_anchors`
 

--- a/modules/local/compute_anchor_scores.nf
+++ b/modules/local/compute_anchor_scores.nf
@@ -7,6 +7,8 @@ process COMPUTE_ANCHOR_SCORES {
 
     input:
     path ch_targets_samplesheet
+    val bound_distance
+    val max_distance
 
     output:
     path outfile_counts_distances   , emit: anchor_target_counts
@@ -22,6 +24,8 @@ process COMPUTE_ANCHOR_SCORES {
     """
     compute_anchor_scores.py \\
         --samplesheet ${ch_targets_samplesheet} \\
+        --bound_distance ${bound_distance} \\
+        --max_distance ${max_distance} \\
         --outfile_counts_distances ${outfile_counts_distances} \\
         --outfile_anchor_scores ${outfile_anchor_scores} \\
         --outfile_anchor_fasta ${outfile_anchor_fasta} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,8 @@ params {
     num_keep_anchors            = 10000
     use_std                     = false
     compute_target_distance     = true
+    bound_distance              = true
+    max_distance                = 10
 
     // Optional Inputs
     reannotate                  = false

--- a/subworkflows/local/analyze_fastqs.nf
+++ b/subworkflows/local/analyze_fastqs.nf
@@ -120,7 +120,9 @@ workflow ANALYZE_FASTQS {
     // Process to get anchor scores and anchor-target counts
     */
     COMPUTE_ANCHOR_SCORES(
-        targets_samplesheet
+        targets_samplesheet,
+        params.bound_distance,
+        params.max_distance
     )
 
     // create samplesheet of bowtie2 indices


### PR DESCRIPTION
- add `bound_distance` and `max_distance` params
- defaults to `bound_distance=true` and `max_distance=10`
- these parameters allow for a maximum distance of `max_distance` in the anchor_score computation