### PR TITLE
Add a new profile to nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -188,6 +188,27 @@ profiles {
         params.star_index                  = "/oak/stanford/groups/horence/Roozbeh/single_cell_project/SICILIAN_references/human/SICILIAN_human_hg38_Refs/star_ref_file/hg38_ERCC_STAR_2.7.5.a"
         params.gtf                         = "/oak/stanford/groups/horence/Roozbeh/single_cell_project/SICILIAN_references/human/SICILIAN_human_hg38_Refs/gtf_file/grch38_known_genes.gtf"
     }
+    horence_no_quake {
+        process.executor = 'slurm'
+        process.clusterOptions      = '-p horence,owners --requeue'
+        process.queueSize           = 50
+        process.pollInterval        = '3 min'
+        process.dumpInterval        = '6 min'
+        process.queueStatInterval   = '5 min'
+        process.exitReadTimeout     = '13 min'
+        process.submitRateLimit     = '5sec'
+        process.memory              = { 20.GB * task.attempt }
+        process.time                = { 1.h * task.attempt }
+        process.errorStrategy       = { task.exitStatus in [130,140,143,137,104,134,139] ? 'retry' : 'finish' }
+        process.maxRetries          = 3
+        params.max_cpus             = 8
+        params.element_annotations_samplesheet = "/oak/stanford/groups/horence/kaitlin/bowtie2_annotations/references/bowtie2_index_samplesheet.csv"
+        params.genome_index                = "/oak/stanford/groups/horence/kaitlin/bowtie2_annotations/references/base_references/grch38_1kgmaj/grch38_1kgmaj"
+        params.transcriptome_index         = "/oak/stanford/groups/horence/circularRNApipeline_Cluster/index/GRCh38.gencode.v31_transcriptome"
+        params.gene_bed                    = "/oak/stanford/groups/horence/kaitlin/annotation_beds/cleaned_hg38_genes.bed"
+        params.star_index                  = "/oak/stanford/groups/horence/Roozbeh/single_cell_project/SICILIAN_references/human/SICILIAN_human_hg38_Refs/star_ref_file/hg38_ERCC_STAR_2.7.5.a"
+        params.gtf                         = "/oak/stanford/groups/horence/Roozbeh/single_cell_project/SICILIAN_references/human/SICILIAN_human_hg38_Refs/gtf_file/grch38_known_genes.gtf"
+    }
     conda {
         params.enable_conda         = true
         docker.enabled              = false


### PR DESCRIPTION
`horence_no_quake` contains cluster options, `horence`, `owners` (no `quake`). 
